### PR TITLE
Get rid of undeclared dependency on resclasses

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -13,6 +13,8 @@ Subtitle := "Construct an equivalent lazy category out of a CAP category",
 Version := Maximum( [
                    "2020.04.22", ## Mohamed's version
                    ## this line prevents merge conflicts
+                   "2020.04.27", ## Fabian's version
+                   ## this line prevents merge conflicts
                    ] ),
 
 Date := ~.Version{[ 1 .. 10 ]},

--- a/gap/LazyCategory.gi
+++ b/gap/LazyCategory.gi
@@ -741,7 +741,7 @@ InstallValue( RECORD_OF_COMPACT_NAMES_OF_CATEGORICAL_OPERATIONS,
 ##
 InstallGlobalFunction( CAP_INTERNAL_COMPACT_NAME_OF_CATEGORICAL_OPERATION,
   function( name )
-    local l, posUniv, posCaps, posWith, posFrom, posInto, posOf, posHom, cname;
+    local l, posUniv, posCaps, posWith, posFrom, posInto, i, posOf, posHom, cname;
     
     if IsBound( RECORD_OF_COMPACT_NAMES_OF_CATEGORICAL_OPERATIONS.(name) ) then
         return RECORD_OF_COMPACT_NAMES_OF_CATEGORICAL_OPERATIONS.(name);
@@ -754,12 +754,14 @@ InstallGlobalFunction( CAP_INTERNAL_COMPACT_NAME_OF_CATEGORICAL_OPERATION,
     posWith := PositionSublist( name, "WithGiven" );
     posFrom := PositionSublist( name, "From" );
     posInto := PositionSublist( name, "Into" );
-    posOf := PositionsSublist( name, "Of" );
+    # find last occurrence of "Of"
+    for i in [ Length( name ) - 2 .. 0 ] do
+        posOf := PositionSublist( name, "Of", i );
+        if posOf <> fail then
+            break;
+        fi;
+    od;
     posHom := PositionSublist( name, "HomomorphismStructure" );
-    
-    if not IsEmpty( posOf ) then
-        posOf := posOf[Length( posOf )];
-    fi;
     
     cname := name;
     


### PR DESCRIPTION
The helper operation "PositionsSublist" is part of the package "resclasses".

Note: I have not tested this explicitly since I'm not sure when/how this code is called.