### PR TITLE
Adjust to https://github.com/homalg-project/CAP_project/pull/808

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "LazyCategories",
 Subtitle := "Construct an equivalent lazy category out of a CAP category",
-Version := "2021.12-04",
+Version := "2022.01-01",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",

--- a/gap/LazyCategory.gi
+++ b/gap/LazyCategory.gi
@@ -891,6 +891,8 @@ InstallMethod( LazyCategory,
             
             HC := LazyCategory( HC : lazify_range_of_hom_structure := false );
             
+            SetRangeCategoryOfHomomorphismStructure( D, HC );
+            
             if CanCompute( C, "DistinguishedObjectOfHomomorphismStructure" ) then
                 AddDistinguishedObjectOfHomomorphismStructure( D,
                   function( D )
@@ -938,6 +940,8 @@ InstallMethod( LazyCategory,
             
         else
             
+            SetRangeCategoryOfHomomorphismStructure( D, HC );
+            
             if CanCompute( C, "DistinguishedObjectOfHomomorphismStructure" ) then
                 AddDistinguishedObjectOfHomomorphismStructure( D,
                   function( D )
@@ -984,8 +988,6 @@ InstallMethod( LazyCategory,
             fi;
             
         fi;
-        
-        SetRangeCategoryOfHomomorphismStructure( D, HC );
         
     fi;
     


### PR DESCRIPTION
Set range category of homomorphism structure before calling corresponding
Add functions. This change is backwards compatible, so we do not have to
bump the version of the dependency on CAP.