### PR TITLE
comply with MonoidalCategories v2022.06-03

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "LazyCategories",
 Subtitle := "Construct an equivalent lazy category out of a CAP category",
-Version := "2022.06-01",
+Version := "2022.06-02",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
@@ -73,7 +73,7 @@ Dependencies := rec(
                    [ "GAPDoc", ">= 1.5" ],
                    [ "ToolsForHomalg", ">= 2021.12-02" ],
                    [ "CAP", ">= 2022.05-04" ],
-                   [ "MonoidalCategories", ">= 2022.04-02" ],
+                   [ "MonoidalCategories", ">= 2022.06-03" ],
                    [ "CategoryConstructor", ">= 2022.04-06" ],
                    [ "Toposes", ">= 2022.04-19" ],
                    [ "Digraphs", ">= 0.12.1" ],

--- a/examples/TerminalCategory.g
+++ b/examples/TerminalCategory.g
@@ -10,11 +10,11 @@ LoadPackage( "SubcategoriesForCAP" );
 
 #! @Example
 T := TerminalCategoryWithMultipleObjects( );
-#! TerminalCategoryWithMultipleObjects
+#! TerminalCategoryWithMultipleObjects( )
 L := LazyCategory( T : primitive_operations := true, optimize := 0 );
-#! LazyCategory( TerminalCategoryWithMultipleObjects )
+#! LazyCategory( TerminalCategoryWithMultipleObjects( ) )
 a := "a" / T / L;
-#! <An evaluated object in LazyCategory( TerminalCategoryWithMultipleObjects )>
+#! <An evaluated object in LazyCategory( TerminalCategoryWithMultipleObjects( ) )>
 Display( a );
 #! a
 #! 
@@ -22,7 +22,7 @@ Display( a );
 IsWellDefined( a );
 #! true
 aa := ObjectConstructor( T, "a" ) / L;
-#! <An evaluated object in LazyCategory( TerminalCategoryWithMultipleObjects )>
+#! <An evaluated object in LazyCategory( TerminalCategoryWithMultipleObjects( ) )>
 Display( aa );
 #! a
 #! 
@@ -30,7 +30,7 @@ Display( aa );
 a = aa;
 #! true
 b := "b" / T / L;
-#! <An evaluated object in LazyCategory( TerminalCategoryWithMultipleObjects )>
+#! <An evaluated object in LazyCategory( TerminalCategoryWithMultipleObjects( ) )>
 Display( b );
 #! b
 #! 
@@ -38,20 +38,20 @@ Display( b );
 a = b;
 #! false
 t := TensorProduct( a, b );
-#! <An object in LazyCategory( TerminalCategoryWithMultipleObjects )>
+#! <An object in LazyCategory( TerminalCategoryWithMultipleObjects( ) )>
 Display( t );
 #! TensorProductOnObjects(
 #! <An evaluated object in
-#!  LazyCategory( TerminalCategoryWithMultipleObjects )>,
+#!  LazyCategory( TerminalCategoryWithMultipleObjects( ) )>,
 #! <An evaluated object in
-#!  LazyCategory( TerminalCategoryWithMultipleObjects )> )
+#!  LazyCategory( TerminalCategoryWithMultipleObjects( ) )> )
 a = t;
 #! false
 TensorProduct( a, a ) = t;
 #! false
 m := MorphismConstructor( EvaluatedCell( a ), "m", EvaluatedCell( b ) ) / L;
 #! <An evaluated morphism in
-#!  LazyCategory( TerminalCategoryWithMultipleObjects )>
+#!  LazyCategory( TerminalCategoryWithMultipleObjects( ) )>
 Display( m );
 #! a
 #! |
@@ -64,7 +64,7 @@ IsWellDefined( m );
 #! true
 n := MorphismConstructor( EvaluatedCell( a ), "n", EvaluatedCell( b ) ) / L;
 #! <An evaluated morphism in
-#!  LazyCategory( TerminalCategoryWithMultipleObjects )>
+#!  LazyCategory( TerminalCategoryWithMultipleObjects( ) )>
 Display( n );
 #! a
 #! |
@@ -81,22 +81,22 @@ m = n;
 #! true
 id := IdentityMorphism( a );
 #! <An identity morphism in
-#!  LazyCategory( TerminalCategoryWithMultipleObjects )>
+#!  LazyCategory( TerminalCategoryWithMultipleObjects( ) )>
 Display( id );
 #! IdentityMorphism( <An evaluated object in
-#! LazyCategory( TerminalCategoryWithMultipleObjects )> )
+#! LazyCategory( TerminalCategoryWithMultipleObjects( ) )> )
 m = id;
 #! false
 id = MorphismConstructor( EvaluatedCell( a ), "xy", EvaluatedCell( a ) ) / L;
 #! true
 z := ZeroMorphism( a, a );
-#! <A zero morphism in LazyCategory( TerminalCategoryWithMultipleObjects )>
+#! <A zero morphism in LazyCategory( TerminalCategoryWithMultipleObjects( ) )>
 Display( z );
 #! ZeroMorphism(
 #! <An evaluated object in
-#!  LazyCategory( TerminalCategoryWithMultipleObjects )>,
+#!  LazyCategory( TerminalCategoryWithMultipleObjects( ) )>,
 #! <An evaluated object in
-#!  LazyCategory( TerminalCategoryWithMultipleObjects )> )
+#!  LazyCategory( TerminalCategoryWithMultipleObjects( ) )> )
 id = z;
 #! true
 #! @EndExample


### PR DESCRIPTION
renamed "TerminalCategoryWithMultipleObjects" -> "TerminalCategoryWithMultipleObjects( )"